### PR TITLE
gsp-dba-maven-pluginをバージョンアップ

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
       <plugin>
         <groupId>jp.co.tis.gsp</groupId>
         <artifactId>gsp-dba-maven-plugin</artifactId>
-        <version>5.1.0</version>
+        <version>5.2.0-SNAPSHOT</version>
         <configuration>
           <erdFile>src/main/resources/entity/data-model.edm</erdFile>
           


### PR DESCRIPTION
https://github.com/coastland/gsp-dba-maven-plugin/pull/215 の対応の取り込み。

`mvn compile`を実行し、gsp-dba-maven-pluginのバージョンが`5.2.0-SNAPSHOT`となっていることを確認。